### PR TITLE
feat(password): initial guidance

### DIFF
--- a/1019-password-design-guidance.md
+++ b/1019-password-design-guidance.md
@@ -1,0 +1,22 @@
+---
+category: component design guidance
+state: draft
+created: 2024-10-22
+updated: 2024-10-22
+---
+
+# Password Component
+
+A [password](https://clarity.design/documentation/password) component is a specialized input field with the ability to toggle between a masked field or to view the password in plain text.
+
+## Guidance
+
+- **Must** use a password field when the user needs to set or input the password.
+- **Must not** use an asterisk (`*`) in the password field.
+- **Should** show password requirements in the helper text to guide the user.
+- **Should not** hide the helper requirements in a signpost or reveal them only after the user fails the first attempt.
+- **May** use a password field when the user needs to mask the input content.
+
+## Changelog
+
+- **2024-10-22**: Initial guidance

--- a/1019-password-design-guidance.md
+++ b/1019-password-design-guidance.md
@@ -1,6 +1,6 @@
 ---
 category: component design guidance
-state: draft
+state: approved
 created: 2024-10-30
 updated: 2024-10-30
 ---

--- a/1019-password-design-guidance.md
+++ b/1019-password-design-guidance.md
@@ -5,17 +5,17 @@ created: 2024-10-22
 updated: 2024-10-22
 ---
 
-# Password Component
+# Password Design Guidance
 
-A [password](https://clarity.design/documentation/password) component is a specialized input field with the ability to toggle between a masked field or to view the password in plain text.
+A [password](https://clarity.design/documentation/password) component is an input field that allows users to toggle between hiding or showing the password in plain text.
 
 ## Guidance
 
-- **Must** use a password field when the user needs to set or input the password.
-- **Must not** use an asterisk (`*`) in the password field.
-- **Should** show password requirements in the helper text to guide the user.
-- **Should not** hide the helper requirements in a signpost or reveal them only after the user fails the first attempt.
-- **May** use a password field when the user needs to mask the input content.
+- Design teams **must** use a password field when the user needs to set or input a password. This ensures security and consistency across the interface.
+- Design teams **must not** use an asterisk (\*) in the password field. Instead, use dots or bullets to mask the password for consistency and clarity.
+- Design teams **should** show password requirements in the helper text to guide the user, helping them create valid passwords without confusion.
+- Design teams **should** not hide password requirements in a signpost or reveal them only after the user fails the first attempt. Providing them upfront helps prevent frustration and improves the user experience.
+- Design teams **may** use a password field when the user needs to mask the input content to protect sensitive information, even if it is not a password.
 
 ## Changelog
 

--- a/1019-password-design-guidance.md
+++ b/1019-password-design-guidance.md
@@ -1,8 +1,8 @@
 ---
 category: component design guidance
 state: draft
-created: 2024-10-22
-updated: 2024-10-22
+created: 2024-10-30
+updated: 2024-10-30
 ---
 
 # Password Design Guidance
@@ -19,4 +19,4 @@ A [password](https://clarity.design/documentation/password) component is an inpu
 
 ## Changelog
 
-- **2024-10-22**: Initial guidance
+- **2024-10-30**: Initial guidance


### PR DESCRIPTION
Added initial guidance for password component.

[CDE-2381](https://vmw-jira.broadcom.net/browse/CDE-2381)-Create MD file with Clarity Design Guidelines for password component.