### PR TITLE
fix: use correct markup and font size for index links

### DIFF
--- a/guidance.clarity.design/src/app/components/cip-index/cip-index.component.html
+++ b/guidance.clarity.design/src/app/components/cip-index/cip-index.component.html
@@ -13,9 +13,7 @@
         <tr>
           <td class="cip-listing__number">{{ page.number }}</td>
           <td class="cip-listing__title">
-            <h3 cds-text="section" cds-layout="display:inline">
-              <a [routerLink]="['/', page.number]">{{ page.title }}</a>
-            </h3>
+            <a cds-text="link" [routerLink]="['/', page.number]">{{ page.title }}</a>
             @if (page.state === 'draft') {
               <span class="badge badge-danger">Draft</span>
             } @else if (page.state === 'review') {


### PR DESCRIPTION
I have no idea why the `h3` element was there. I must have made some copy/paste mistake when writing that.