### PR TITLE
chore: disable concurrent build cancellation

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
   merge_group:
 
-concurrency:
-  group: pr-build-${{github.event.pull_request.number}}
-  cancel-in-progress: ${{github.event_name == 'pull_request'}}
-
 jobs:
   pr-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I can't seem to get this to work properly with merge groups.